### PR TITLE
Adding homepage URL to Qiskit AER setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
     packages=find_qiskit_aer_packages() if not dummy_install else [],
     cmake_source_dir='.',
     description="Qiskit Aer - High performance simulators for Qiskit",
+    url="https://github.com/Qiskit/qiskit-aer",
     author="AER Development Team",
     author_email="qiskit@us.ibm.com",
     license="Apache 2.0",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As proposed in issue https://github.com/Qiskit/qiskit-aer/issues/40, we should add the Qiskit AER's homepage URL to the setup.py file. This info is shown as part of the installation details when using commands like pip show qiskit-aer and this is the only common Qiskit package that lacks it.

### Details and comments


